### PR TITLE
Add: HMRC Fraud Prevention Headers

### DIFF
--- a/uk_vat/uk_vat_return/doctype/hmrc_api_settings/hmrc_api_settings.json
+++ b/uk_vat/uk_vat_return/doctype/hmrc_api_settings/hmrc_api_settings.json
@@ -9,6 +9,8 @@
   "oauth2_client_identifier_section",
   "client_id",
   "client_secret",
+  "fraud_prevention_section_header",
+  "gov_ip_headers",
   "advanced_section",
   "auth_base",
   "api_base",
@@ -65,11 +67,24 @@
    "fieldname": "advanced_section",
    "fieldtype": "Section Break",
    "label": "Advanced"
+  },
+  {
+   "default": "0",
+   "description": "For proper operation, you need to enable this and then provide the following HTTP headers to this application: Gov-Client-Public-IP, Gov-Client-Public-IP-Timestamp, Gov-Client-Public-Port, Gov-Vendor-Public-IP, Gov-Vendor-Forwarded. The spec for these headers is here: https://developer.service.hmrc.gov.uk/guides/fraud-prevention/connection-method/web-app-via-server/\n\nIf this is disabled, this app won't submit these headers to the HMRC API.",
+   "fieldname": "gov_ip_headers",
+   "fieldtype": "Check",
+   "label": "GOV IP Headers"
+  },
+  {
+   "fieldname": "fraud_prevention_section_header",
+   "fieldtype": "Section Break",
+   "label": "HMRC Fraud Prevention Headers"
   }
  ],
+ "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2020-04-11 15:55:09.575127",
+ "modified": "2021-04-14 18:37:58.394446",
  "modified_by": "Administrator",
  "module": "UK VAT Return",
  "name": "HMRC API Settings",

--- a/uk_vat/uk_vat_return/doctype/hmrc_authorisations/hmrc_authorisations.py
+++ b/uk_vat/uk_vat_return/doctype/hmrc_authorisations/hmrc_authorisations.py
@@ -14,7 +14,7 @@ class HMRCAuthorisations(Document):
 	pass
 
 def get_redirect_uri():
-	return get_request_site_address(True) + "?cmd=erpnext.regional.doctype.hmrc_authorisations.hmrc_authorisations.hmrc_callback"
+	return get_request_site_address(True) + "?cmd=uk_vat.uk_vat_return.doctype.hmrc_authorisations.hmrc_authorisations.hmrc_callback"
 
 @frappe.whitelist()
 def authorize_access(name):
@@ -75,11 +75,11 @@ def hmrc_callback(code=None, state=None,
 			include_client_id=True)
 
 	frappe.db.set_value("HMRC Authorisations", name, "oauth_token", json.dumps(token))
-	frappe.db.set_value("HMRC Authorisations", name, "authorisation_status", 
+	frappe.db.set_value("HMRC Authorisations", name, "authorisation_status",
 					        "Authorised")
-	frappe.db.set_value("HMRC Authorisations", name, "authorised_services", 
+	frappe.db.set_value("HMRC Authorisations", name, "authorised_services",
 					        " ".join(token["scope"]))
-	frappe.db.set_value("HMRC Authorisations", name, "last_authorised_date", 
+	frappe.db.set_value("HMRC Authorisations", name, "last_authorised_date",
 					    datetime.datetime.now())
 	frappe.db.commit()
 
@@ -91,7 +91,7 @@ def get_session(company):
 
 	name, token_string = frappe.db.sql("""
 				select name, oauth_token from `tabHMRC Authorisations` a
-				where 
+				where
 					a.company = %s and
 					a.authorisation_status = "Authorised"
 				""", company)[0]
@@ -116,3 +116,4 @@ def get_session(company):
 						auto_refresh_kwargs=extra,
 						auto_refresh_url=api_base+'/oauth/token',
 						token_updater=token_updater)
+

--- a/uk_vat/uk_vat_return/doctype/uk_vat_return/uk_vat_return.js
+++ b/uk_vat/uk_vat_return/doctype/uk_vat_return/uk_vat_return.js
@@ -1,9 +1,24 @@
 // Copyright (c) 2020 Software to Hardware Ltd. and contributors
 // For license information, please see license.txt
 
+var fraud_prevention_headers = function() {
+    return {
+        "TimezoneOffsetMinutes": `${new Date().getTimezoneOffset()}`,
+        "ScreenWidth": `${screen.width}`,
+        "ScreenHeight": `${screen.height}`,
+        "ScreenScalingFactor": `${window.devicePixelRatio}`,
+        "ScreenColorDepth": `${screen.colorDepth}`,
+        "WindowWidth": `${window.innerWidth}`,
+        "WindowHeight": `${window.innerHeight}`,
+        "UA": `${navigator.userAgent}`,
+        "Plugins": Array.from(navigator.plugins, plugin => plugin && plugin.name)
+                    .filter((name) => name).join(",")
+    }
+}
+
 frappe.ui.form.on('UK VAT Return', {
 	refresh: function(frm) {
-		
+
 		if(!frm.is_new()) {
 
 			if (!frm.doc.docstatus==1) {
@@ -11,12 +26,12 @@ frappe.ui.form.on('UK VAT Return', {
 					frm.save()
 				});
 			}
-			
+
 			frm.add_custom_button(__('Show drilldown'), function() {
 				frappe.set_route("query-report", "UK VAT Return Drilldown",
 					{"company": frm.doc.company,
-					"period_start_date": frm.doc.period_start_date,
-					"period_end_date": frm.doc.period_end_date});
+					 "period_start_date": frm.doc.period_start_date,
+					 "period_end_date": frm.doc.period_end_date});
 			});
 
 
@@ -30,6 +45,7 @@ frappe.ui.form.on('UK VAT Return', {
 			"method" : "uk_vat.uk_vat_return.doctype.uk_vat_return.uk_vat_return.get_open_obligations",
 			"args" : {
 				company_name : frm.doc.company,
+                fraud_prevention: fraud_prevention_headers()
 			},
 			"callback" : function(r) {
 
@@ -69,12 +85,12 @@ frappe.ui.form.on('UK VAT Return', {
 						d.hide();
 					}
 				});
-				
+
 				d.show();
-				
+
 			}
 		});
-		
+
 	},
 
 	submit_to_hmrc: function(frm) {
@@ -87,7 +103,8 @@ frappe.ui.form.on('UK VAT Return', {
 					"method" : "uk_vat.uk_vat_return.doctype.uk_vat_return.uk_vat_return.submit_vat_return",
 					"args" : {
 						name : frm.doc.name,
-						is_finalised: frm.doc.is_finalised
+						is_finalised: frm.doc.is_finalised,
+                        fraud_prevention: fraud_prevention_headers()
 					},
 					"callback" : function(r) {
 						frappe.msgprint("VAT return submitted to HMRC!");
@@ -95,7 +112,7 @@ frappe.ui.form.on('UK VAT Return', {
 					}
 				});
 
-				
+
 			},
 			function(){
 				show_alert('VAT return was NOT submitted.')

--- a/uk_vat/uk_vat_return/hmrc_api/fraud_prevention.py
+++ b/uk_vat/uk_vat_return/hmrc_api/fraud_prevention.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Software to Hardware Ltd. and contributors
+# For license information, please see license.txt
+
+import platform
+import hashlib
+import frappe
+import urllib.parse
+from datetime import datetime, timezone
+import uuid
+import json
+
+DEVICE_ID_COOKIE = "Gov-Client-Device-ID"
+
+def get_fraud_prevention_headers():
+
+    utc_now = datetime.now(timezone.utc).isoformat()[0:23] + "Z"
+
+    h = {}
+    h["Gov-Client-Connection-Method"] = "WEB_APP_VIA_SERVER"
+    h["Gov-Client-Browser-Do-Not-Track"] = str(
+        bool(frappe.request.headers.get("DNT"))).lower()
+    h["Gov-Vendor-License-IDs"] = "{}={}".format(
+        "ERPNext", hashlib.sha256(b"OPEN SOURCE").hexdigest())
+    h["Gov-Vendor-Product-Name"] = "ERPNext-MTD-VAT-Module"
+    h["Gov-Vendor-Version"] = "erpnext-mtd-module=1.0&{}={}".format(
+        platform.system(), platform.release()
+    )
+
+    # Get or generate and store client device ID
+    client_device_id = frappe.request.cookies.get(DEVICE_ID_COOKIE)
+    if not client_device_id:
+        client_device_id = str(uuid.uuid4())
+        frappe.local.cookie_manager.set_cookie(DEVICE_ID_COOKIE,
+            client_device_id)
+    h["Gov-Client-Device-ID"] = client_device_id
+
+    # Client address
+    # In production this should come from your proxy front end
+    if frappe.db.get_single_value("HMRC API Settings", "gov_ip_headers"):
+        for hdr in ("Gov-Client-Public-IP", "Gov-Client-Public-IP-Timestamp",
+                    "Gov-Client-Public-Port", "Gov-Vendor-Public-IP",
+                    "Gov-Vendor-Forwarded"):
+            h[hdr] = frappe.get_request_header(hdr)
+    else:
+        h["Gov-Client-Public-IP"] = frappe.request.remote_addr
+        h["Gov-Client-Public-IP-Timestamp"] = utc_now
+        h["Gov-Client-Public-Port"] = ""
+        h["Gov-Vendor-Forwarded"] = ""
+        h["Gov-Vendor-Public-IP"] = ""
+
+    # Headers from this application
+    h["Gov-Client-User-IDs"] = "frappe={}".format(
+        urllib.parse.quote(frappe.session.user))
+
+    # Headers from client javascript
+    chdr = json.loads(frappe.request.form["fraud_prevention"])
+    h["Gov-Client-Browser-JS-User-Agent"] = chdr.get("UA")
+    tzoffset_minutes = chdr.get("TimezoneOffsetMinutes")
+    if tzoffset_minutes is not None:
+        tzoffset_minutes = int(tzoffset_minutes)
+        h["Gov-Client-Timezone"] = "UTC{}{:02d}:{:02d}".format(
+            "-" if tzoffset_minutes >= 0 else "+", # Direction is ok
+            abs(tzoffset_minutes) // 60,
+            abs(tzoffset_minutes) % 60
+        )
+    h["Gov-Client-Window-Size"] = "width={}&height={}".format(
+        chdr["WindowWidth"], chdr["WindowHeight"]
+    )
+    h["Gov-Client-Screens"] = "width={}&height={}&scaling-factor={}&colour-depth={}".format(
+        chdr["ScreenWidth"], chdr["ScreenHeight"], chdr["ScreenScalingFactor"],
+        chdr["ScreenColorDepth"]
+    )
+
+    h["Gov-Client-Browser-Plugins"] = chdr["Plugins"]
+
+    # Suggested method does not work. If GOV wants these then GOV can tell us
+    # how they want us to get them.
+    h["Gov-Client-Local-IPs"] = ""
+    h["Gov-Client-Local-IPs-Timestamp"] = ""
+
+    # We don't use multi-factor.
+    h["Gov-Client-Multi-Factor"] = ""
+
+    return h
+
+@frappe.whitelist()
+def http_header_feedback():
+    return frappe.request.headers
+

--- a/uk_vat/uk_vat_return/hmrc_api/vat.py
+++ b/uk_vat/uk_vat_return/hmrc_api/vat.py
@@ -2,8 +2,11 @@
 # Copyright (c) 2020 Software to Hardware Ltd. and contributors
 # For license information, please see license.txt
 
+import platform
+import hashlib
 import frappe
 from uk_vat.uk_vat_return.doctype.hmrc_authorisations.hmrc_authorisations import get_session
+from .fraud_prevention import get_fraud_prevention_headers
 
 accept_header = { "Accept": "application/vnd.hmrc.1.0+json" }
 
@@ -14,7 +17,7 @@ def is_company_vat_enabled(company):
 
     enabled_count = frappe.db.sql("""
                 select count(name) `tabHMRC Authorisations` a
-                where 
+                where
                     a.company = %s and
                     a.authorisation_status = "Authorised"
                 """, company)[0][0]
@@ -28,23 +31,35 @@ def get_vrn(company):
     return tax_id[2:]
 
 def get_open_obligations(company):
+    h = {}
+    h.update(accept_header)
+    h.update(get_fraud_prevention_headers())
+
     oauth = get_session(company)
     vrn = get_vrn(company)
     api_base = frappe.db.get_single_value("HMRC API Settings", "api_base")
     response = oauth.get(
         api_base+"/organisations/vat/%s/obligations?status=O" % vrn,
-        headers=accept_header).json()
+            headers=h).json()
     if "obligations" not in response:
-        frappe.throw("Message from HMRC: " + response["message"], 
+        frappe.throw("Message from HMRC: " + response["message"],
                      "Error retrieving obligations")
     return response["obligations"]
 
 def submit_return(company, vat_return):
     oauth = get_session(company)
     vrn = get_vrn(company)
-    api_base = frappe.db.get_single_value("HMRC API Settings", "api_base")    
+    api_base = frappe.db.get_single_value("HMRC API Settings", "api_base")
     response = oauth.post(api_base+"/organisations/vat/%s/returns" % vrn,
             headers = accept_header, json = vat_return)
-    
+
     return response.json(), response.headers
 
+@frappe.whitelist()
+def fraud_prevention_header_feedback(company):
+    oauth = get_session(company)
+    api_base = frappe.db.get_single_value("HMRC API Settings", "api_base")
+    response = oauth.get(
+        api_base+"/test/fraud-prevention-headers/vat-mtd/validation-feedback",
+        headers=accept_header)
+    return response.json()


### PR DESCRIPTION
HMRC require additional HTTP headers to be sent to their API. This patch adds these
headers. Note, your proxy must provide some additional headers to fully use this patch.